### PR TITLE
feat: Add method to call values that are outside of a group in a data…

### DIFF
--- a/Summary of Python libraries.ipynb
+++ b/Summary of Python libraries.ipynb
@@ -2401,7 +2401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 4,
    "metadata": {
     "scrolled": true
    },
@@ -2469,7 +2469,7 @@
        "3    4    OR        NaN"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3333,7 +3333,7 @@
    "cell_type": "code",
    "execution_count": 90,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
@@ -3415,6 +3415,30 @@
     "#To select only the columns of interest\n",
     "df_6=df[['address', 'city', 'name']]\n",
     "df_6.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2    TX\n",
+       "3    OR\n",
+       "Name: Place, dtype: object"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# To show only not selected values in a column using isin()\n",
+    "top=['NY', 'CA']\n",
+    "df_5.loc[~df_5['Place'].isin(top),'Place']"
    ]
   },
   {


### PR DESCRIPTION
…frames column. Some good points about this method are:

- Add isin() command for dataframes
- The method is useful for when we are categorizing the values of a column, and you want to circle all the values outside the most frequent in a single value
- The method show how to use ~ in python, which is useful to show the complementary values that are outside of a query

Resolves: #8