### PR TITLE
feat: Add method to select only complete row in dataframes

### DIFF
--- a/Summary of Python libraries.ipynb
+++ b/Summary of Python libraries.ipynb
@@ -2401,7 +2401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "scrolled": true
    },
@@ -2469,7 +2469,7 @@
        "3    4    OR        NaN"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2489,7 +2489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -2555,7 +2555,7 @@
        "3   4    OR                  NaN"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2568,7 +2568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -2634,7 +2634,7 @@
        "3   4       OR                  NaN"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2656,7 +2656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -2668,7 +2668,7 @@
        "Name: 2, dtype: object"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2681,7 +2681,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -2740,7 +2740,7 @@
        "2   3       TX                 90.0"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2752,7 +2752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -2811,7 +2811,7 @@
        "3   4       OR                  NaN"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2824,7 +2824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -2883,7 +2883,7 @@
        "3   4       OR                  NaN"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2895,7 +2895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -2954,7 +2954,7 @@
        "2   4       OR                  NaN"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2967,7 +2967,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 11,
    "metadata": {
     "scrolled": false
    },
@@ -3014,7 +3014,7 @@
        "3   4       OR                  NaN"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3026,7 +3026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -3078,7 +3078,7 @@
        "1   2       CA                120.0"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3090,7 +3090,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -3135,7 +3135,7 @@
        "3   4       OR                  NaN"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3143,6 +3143,78 @@
    "source": [
     "# To select rows where a value is missing, i.e. it is NaN.\n",
     "df_5[df_5['Number of Employees'].isnull()==True]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>Location</th>\n",
+       "      <th>Number of Employees</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>NY</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>CA</td>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>90.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   ID Location  Number of Employees\n",
+       "0   1       NY                100.0\n",
+       "1   2       CA                120.0\n",
+       "2   3       TX                 90.0"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# To select the rows without missing values\n",
+    "df_5.dropna(axis = 0, how = 'any', inplace = True)\n",
+    "df_5"
    ]
   },
   {


### PR DESCRIPTION
The method is similar to complete.cases() in R. It is useful for preprocessing datasets for machine learning models

Resolves: #10