### PR TITLE
feat: Add stratified sampling in scikit

### DIFF
--- a/Summary of Python libraries.ipynb
+++ b/Summary of Python libraries.ipynb
@@ -11821,6 +11821,106 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Stratified sampling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.0    0.350581\n",
+       "2.0    0.318847\n",
+       "4.0    0.176308\n",
+       "5.0    0.114438\n",
+       "1.0    0.039826\n",
+       "Name: income_cat, dtype: float64"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Using california's housing dataset from the 90s\n",
+    "housing=pd.read_csv(\"https://raw.githubusercontent.com/ageron/handson-ml/master/datasets/housing/housing.csv\")\n",
+    "# Creating a new category called income_cat\n",
+    "# The median income is divided by 1.5 to limit the number of categories\n",
+    "# Greater than 5 were added to 5 to make it representative\n",
+    "housing[\"income_cat\"] = np.ceil(housing[\"median_income\"] / 1.5)\n",
+    "housing[\"income_cat\"].where(housing[\"income_cat\"] < 5, 5.0, inplace=True)\n",
+    "# To do stratified sampling based on the income category\n",
+    "# The median income is chosen as attribute to stratify as it is believed \n",
+    "# as a strong indicator of median housing price\n",
+    "from sklearn.model_selection import StratifiedShuffleSplit\n",
+    "split = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=42)\n",
+    "for train_index, test_index in split.split(housing, housing[\"income_cat\"]):\n",
+    "    strat_train_set = housing.loc[train_index]\n",
+    "    strat_test_set = housing.loc[test_index]\n",
+    "# To see if worked, first look at the original distribution of the data\n",
+    "housing[\"income_cat\"].value_counts() / len(housing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.0    0.350594\n",
+       "2.0    0.318859\n",
+       "4.0    0.176296\n",
+       "5.0    0.114402\n",
+       "1.0    0.039850\n",
+       "Name: income_cat, dtype: float64"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Look the train set distribution\n",
+    "strat_train_set[\"income_cat\"].value_counts()/len(strat_train_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.0    0.350533\n",
+       "2.0    0.318798\n",
+       "4.0    0.176357\n",
+       "5.0    0.114583\n",
+       "1.0    0.039729\n",
+       "Name: income_cat, dtype: float64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Look the test set distribution\n",
+    "strat_test_set[\"income_cat\"].value_counts()/len(strat_test_set)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Linear regression"
    ]
   },


### PR DESCRIPTION
Stratified sampling is useful to keep the distribution
of the data through the train and test datasets. This method
prevent skewness in the data to avoid errors in predictions
and analysis.

For the example is used a dataset found open source thanks
to the book hands on machine learning from Aurelien Geron.

Resolves: #15