### PR TITLE
feat: Add groupby with size()

### DIFF
--- a/3. Intro to Pandas.ipynb
+++ b/3. Intro to Pandas.ipynb
@@ -296,11 +296,11 @@
        "Columbus      72\n",
        "Dallas        66\n",
        "            ... \n",
-       "Dumfries       1\n",
-       "Crowley        1\n",
-       "Nutley         1\n",
-       "Seward         1\n",
-       "Los Banos      1\n",
+       "Nipomo         1\n",
+       "Dresden        1\n",
+       "Edgewood       1\n",
+       "Colusa         1\n",
+       "Abington       1\n",
        "Name: city, Length: 2764, dtype: int64"
       ]
      },
@@ -761,9 +761,9 @@
     {
      "data": {
       "text/plain": [
-       "ID                      3\n",
-       "Location               TX\n",
-       "Number of Employees    90\n",
+       "ID                        3\n",
+       "Location                 TX\n",
+       "Number of Employees    90.0\n",
        "Name: 2, dtype: object"
       ]
      },
@@ -1824,7 +1824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 36,
    "metadata": {
     "scrolled": false
    },
@@ -1905,24 +1905,24 @@
        "256  Jack in the Box   330"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# To group columns by name to know how many there are.\n",
+    "# To group columns by name to know how many there are counting values in city.\n",
     "Restaurant_count = df.groupby('name').city.count().reset_index()\n",
     "# Sorting values from max to min\n",
     "Result= Restaurant_count.sort_values('city',ascending=False)\n",
-    "# To show just top results\n",
+    "# To show just results with more than 300 values\n",
     "The_top=Result[Result.city>300]\n",
     "The_top"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -1932,17 +1932,20 @@
        "McDonald's     1898\n",
        "Taco Bell      1032\n",
        "Burger King     833\n",
-       "Name: id, dtype: int64"
+       "Subway          776\n",
+       "Arby's          663\n",
+       "dtype: int64"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# To group columns by name to know the top 3\n",
-    "df.groupby('name').id.count().nlargest(3).sum(level=0)"
+    "# Simplified version of counting restaurants using size\n",
+    "test=df.groupby('name').size().nlargest(5)\n",
+    "test"
    ]
   },
   {
@@ -5473,7 +5476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Group by with size is a simplified version of using group by in which you only need the grouping variable. nlargest is also used to simplify the code even more.